### PR TITLE
Add CI and linear regression adjustment for Y

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,4 +9,5 @@ License: GPL-3
 Encoding: UTF-8
 LazyData: true
 Imports: biclust,Matrix,stats,lattice
+Suggests: foreach, doParallel
 RoxygenNote: 7.1.1

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,6 +1,7 @@
 importFrom("stats", "rnorm", "runif", "lm", "coef","rbinom")
 importFrom("Matrix", "Matrix")
 importFrom("biclust", "biclust", "bicluster", "BCBimax")
+importFrom("foreach", "%dopar%")
 export(ate)
 export(clique_test)
 export(one_sided_test)

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ library(doParallel)
 numcores = detectCores()
 clst = makeCluster(numcores[1]-1) 
 registerDoParallel(clst)
-CRT = clique_test(Y, Z, Z_a, Z_b, Zobs_id=1, decom='greedy', ret_ci=TRUE, ci_method='grid', minass=15)
+CRT = clique_test(Y, Z, Z_a, Z_b, Zobs_id=1, decom='bimax', ret_ci=TRUE, ci_method='grid', minr=15, minc=15)
 ```
 
 ## Example: Clustered Interference

--- a/README.md
+++ b/README.md
@@ -75,9 +75,10 @@ We can also do parallelization for the grid method by specifying Cluster beforeh
 ```R
 library(doParallel)
 numcores = detectCores()
-clst = makeCluster(numcores[1]-1) 
+clst = makeCluster(numcores-1) # try not to use all cores in order not to impose great burden on the computer
 registerDoParallel(clst)
 CRT = clique_test(Y, Z, Z_a, Z_b, Zobs_id=1, decom='bimax', ret_ci=TRUE, ci_method='grid', minr=15, minc=15)
+stopCluster(clst)
 ```
 
 ## Example: Clustered Interference

--- a/man/ate.Rd
+++ b/man/ate.Rd
@@ -16,5 +16,5 @@ indicating that under this treatment, individual is exposed to \code{b} or \code
 The differenence in means between exposure contrasts \code{b} and \code{a}.
 }
 \description{
-Returns difference in means between exposures \code{b} and \code{a}, coded as \code{1} and \code{-1}, respectively.
+Returns difference in means between exposures \code{b} and \code{a} (as \code{b} - \code{a}), coded as \code{1} and \code{-1}, respectively.
 }

--- a/man/clique_test.Rd
+++ b/man/clique_test.Rd
@@ -4,7 +4,21 @@
 \alias{clique_test}
 \title{The main randomization test function.}
 \usage{
-clique_test(Y, Z, Z_a, Z_b, Zobs_id, decom = "bimax", ...)
+clique_test(
+  Y,
+  Z,
+  Z_a,
+  Z_b,
+  Zobs_id,
+  Xadj = NULL,
+  alpha = 0.05,
+  tau = 0,
+  decom = "bimax",
+  ret_ci = FALSE,
+  ci_dec = 2,
+  ci_method = "grid",
+  ...
+)
 }
 \arguments{
 \item{Y}{The observed outcome vector.}
@@ -17,8 +31,17 @@ clique_test(Y, Z, Z_a, Z_b, Zobs_id, decom = "bimax", ...)
 
 \item{Zobs_id}{The index location of the observed assignment vector in \code{Z}, \code{Z_a}, and \code{Z_b}.}
 
+\item{Xadj}{The covariates that might affect Y. If not \code{NULL}, will replace \code{Y} by the residuals from the linear regression of \code{Y} on \code{Xadj}. Note that users would need to add an intercept to \code{Xadj} manually if they want.
+To adjust \code{Xadj}, pass in \code{Y_adj=TRUE} and a non-empty \code{NULL} that has the same row numbers as \code{Y}.}
+
+\item{alpha}{The significance level. By default it's \eqn{0.05}.}
+
+\item{tau}{The \eqn{\tau} in the null \eqn{Y_i(b) = Y_i(a) + \tau} for all \eqn{i}. By default is \eqn{0}.}
+
 \item{decom}{The algorithm used to calculate the biclique decomposition. Currently supported algorithms
 are "bimax" and "greedy".}
+
+\item{ret_ci}{Whether calculates the \eqn{1-\alpha} confidence interval or not. Default is \code{FALSE}.}
 
 \item{...}{Other stuff ...}
 }


### PR DESCRIPTION
1. Add an option in the clique_test function to calculate CI by inverting the null Y(b) = Y(a) + tau for different tau. The upper bound and lower bound for CI is initialized as quantile(Y[Z_b[,Zobs_id]], 0.95)-quantile(Y[Z_a[,Zobs_id]], 0.05) and quantile(Y[Z_b[,Zobs_id]], 0.05)-quantile(Y[Z_a[,Zobs_id]], 0.95). They are selected based on the equality that tau = Y(b) - Y(a). I choose the 5%-95% quantiles to avoid extreme observations. There are two methods for it:
- A grid method that can be made parallel by specifying makeCluster separately.
- A bisection method, which is more efficient.
2. Add an option in the clique_test function to adjust Y by replacing it with the residuals from the linear regression of Y on Xadj.
3. Update README to reflect the changes, in particular on how to specify tau in the two examples and how to get the CI.