### PR TITLE
Some updates

### DIFF
--- a/R/functions_stats.R
+++ b/R/functions_stats.R
@@ -112,7 +112,7 @@ gen_tstat = function(G, type) {
       e_r = fit0$residuals
       ### T_score?
       Icond = as.logical(is_focal*(R>0))
-      stopifnot("Not enough units to condition on"=(sum(Icond) > 0))
+      if (!(sum(Icond) > 0)) { return(NaN) }
       as.numeric(abs( cov(e_r[Icond], Peer_i[Icond]) ))
     }
   }

--- a/R/functions_stats.R
+++ b/R/functions_stats.R
@@ -118,6 +118,7 @@ gen_tstat = function(G, type) {
   }
   if (type == "htn") {
     f = function(y, z, is_focal){
+      if (sum(is_focal) == 1) { return(NaN) }
       Y_F = y[is_focal]
       sd_F = sd(Y_F)
       neighbor_treated = G %*% (z*(!is_focal)) > 0

--- a/R/maintest.R
+++ b/R/maintest.R
@@ -177,17 +177,17 @@ biclique.decompose = function(Z, hypothesis,
       num_ass = mina
       break_signal = FALSE
 
-      ### should not remove isolated units here, otherwise rownames of multiNEgraph is distorted,
-      ### then get_clique function will go wrong when matching rownames.
-      ### --- has been fixed
-      iremove = which(rowSums(multiNEgraph!=0)==0)  # removes isolated units.
-      if(length(iremove)!=0){ multiNEgraph = multiNEgraph[-iremove,] }
-
       if (dim(multiNEgraph)[2]<=num_ass){ # when remaining cols below threshold mina
-        units_leftover = which(rowSums(multiNEgraph^2)==dim(multiNEgraph^2)[2])
-        themat = multiNEgraph[units_leftover,]
+        units_leftover = which(rowSums(multiNEgraph)==dim(multiNEgraph)[2])
+        themat = multiNEgraph[units_leftover,, drop=F]
         break_signal = TRUE
       } else {
+        ### should not remove isolated units here, otherwise rownames of multiNEgraph is distorted,
+        ### then get_clique function will go wrong when matching rownames.
+        ### --- has been fixed
+        iremove = which(rowSums(multiNEgraph!=0)==0)  # removes isolated units.
+        if(length(iremove)!=0){ multiNEgraph = multiNEgraph[-iremove,] }
+        
         test = out_greedy_decom(multiNEgraph, num_ass)
         themat = test$clique
       }

--- a/R/maintest.R
+++ b/R/maintest.R
@@ -151,7 +151,7 @@ biclique.decompose = function(Z, hypothesis,
       focal_unit = as.integer(rownames(themat))
       focal_ass = as.integer(colnames(themat)); focal_ass_match = Z0[focal_ass]
 
-      Z_m_assignments = Z_m[,focal_ass_match]
+      Z_m_assignments = Z_m[,focal_ass_match, drop=F]
       if (length(focal_ass_match) == 1) {Z_m_assignments = as.matrix(Z_m_assignments)} # N' x 1 clique
       rownames(Z_m_assignments) = 1:num_units
       colnames(Z_m_assignments) = focal_ass_match
@@ -199,7 +199,7 @@ biclique.decompose = function(Z, hypothesis,
         next
       }
 
-      Z_m_assignments = Z_m[,focal_ass_match]
+      Z_m_assignments = Z_m[,focal_ass_match, drop=F]
       rownames(Z_m_assignments) = 1:num_units
       colnames(Z_m_assignments) = focal_ass_match
       MNE = append(MNE, list(list(units = focal_unit, assignments = Z_m_assignments)))

--- a/README.md
+++ b/README.md
@@ -135,13 +135,6 @@ design_fn = function(){
   return(treatment[,'treat'])
 }
 
-# Generate a treatment realization and outcome
-Z = design_fn() # randomly get one realization
-Y = out_bassefeller(N, K, Z, tau_main = 0.4, housestruct = housestruct)$Yobs 
-# here we assume that potential outcomes are 0.4 higher if an untreated unit is in a cluster
-# with a treated unit compared to in a cluster without any treated unit, 
-# i.e., a spillover effect of 0.4 is assumed
-
 # The exposure function: exposure for each unit i is z_i + \sum_{j \in [i]} z_j where [i] represents the cluster i is in.
 exposure_i = function(z, i) {
   # find the household that i is in
@@ -159,6 +152,16 @@ exposure_i = function(z, i) {
 null_equiv = function(exposure_z1, exposure_z2) {
   ((exposure_z1 == 1) | (exposure_z1 == 0)) & ((exposure_z2 == 1) | (exposure_z2 == 0))
 }
+
+# Generate a treatment realization and outcome
+Z = design_fn() # randomly get one realization
+# Generate exposure under the realized Z
+Z_exposure = rep(0, N); for (i in 1:N) { Z_exposure[i] = exposure_i(Z, i) }
+# Generate observed outcomes based on exposures under Z
+Y = out_bassefeller(N, K, Z_exposure, tau_main = 0.4, housestruct = housestruct)$Yobs 
+# here we assume that potential outcomes are 0.4 higher if an untreated unit is in a cluster
+# with a treated unit compared to in a cluster without any treated unit, 
+# i.e., a spillover effect of 0.4 is assumed
 
 # Do biclique decomposition on the null exposure graph
 H0 = list(design_fn=design_fn, exposure_i=exposure_i, null_equiv=null_equiv)


### PR DESCRIPTION
In gen_tstat, we allow functions to return NaN when the clique conditional on is ill-behaved.
In biclique.decompose, maintain the (matrix) shape of multiNEgraph and Z_m when slicing the matrix.
Update the Clustered Interference example in README that out_bassefeller should use exposure under Z not Z itself. 
